### PR TITLE
Mobile first

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,9 @@
 <html>
 <head>
   <title>LittleByLittle</title>
+
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
-  <div class="col-md-12">Board Title</div>
-  <div class="col-md-6">Ready</div>
-  <div class="col-md-3">Doing</div>
-  <div class="col-md-3">Done</div>
+  <div class="col-xs-12">Board Title</div>
+  <div class="col-xs-12 col-sm-6">Ready</div>
+  <div class="col-xs-6 col-sm-3">Doing</div>
+  <div class="col-xs-6 col-sm-3">Done</div>
 </div>


### PR DESCRIPTION
I changed the grid to the pattern that I use with Zurb and Susy: mobile-first layout. You style the smallest unit first (in Bootstrap's case, the 'xs' grid designation), then only add in the changes to that basic design for your larger designs (tablets and desktop.)

:memo: Bootstrap shows this pattern off in these two examples in their grid docs:
http://getbootstrap.com/css/#grid-example-mixed

Someone merge this Pull Request.